### PR TITLE
Use non-colliding artifact id

### DIFF
--- a/projects/location-gateway/pom.xml
+++ b/projects/location-gateway/pom.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redhat</groupId>
-  <artifactId>location-service</artifactId>
+  <artifactId>location-gateway</artifactId>
   <version>1.0.0-SNAPSHOT</version>
-  <name>DAY IN THE LIFE :: Location Service</name>
+  <name>DAY IN THE LIFE :: Location Gateway</name>
   <description>Best Mart Five Minute Pit Stop</description>
   <properties>
     <spring-boot.version>1.5.4.RELEASE</spring-boot.version>


### PR DESCRIPTION
it is a better practice and it allows to have Java completion in Eclipse
Che

Signed-off-by: Aurélien Pupier <apupier@redhat.com>