### PR TITLE
Remove servicesToProvision in customServerConfig.json

### DIFF
--- a/support/install/ansible/playbooks/openshift/roles/setup_webapp/templates/extra-services.yaml.j2
+++ b/support/install/ansible/playbooks/openshift/roles/setup_webapp/templates/extra-services.yaml.j2
@@ -2,12 +2,6 @@ apiVersion: v1
 data:
   customServerConfig.json: |
     {
-      "servicesToProvision": [
-        "fuse",
-        "launcher",
-        "che",
-        "3scale"
-      ],
       "services": [
         { "name": "3scale Developer Dashboard", "url": "https://{{ '{{' }} username {{ '}}' }}.{{ ocp_apps_domain }}" },
         { "name": "3scale Admin Dashboard", "url": "https://{{ '{{' }} username {{ '}}' }}-admin.{{ ocp_apps_domain }}" },


### PR DESCRIPTION
Currently we specify services to be provisioned in the web app
through the servicesToProvision in customServerConfig.json. We no
longer need to do that.

Verification:
- Run the DIL installer
- Login to the web app
- Ensure all services are shown to be provisioned in the loading
screen
- Ensure all right-hand links work on the landing page for the
services

Fixes #267