### PR TITLE
clarify instructions

### DIFF
--- a/docs/labs/citizen-integrator-track/lab03/walkthrough.adoc
+++ b/docs/labs/citizen-integrator-track/lab03/walkthrough.adoc
@@ -38,10 +38,6 @@ Your password is: `{user-password}`
 [id="define-api-proxy"]
 == Define your API Proxy
 
-. Launch a new tab on your web browser.
-. Navigate to the Solution Explorer on that tab.
-. Click on the *Red Hat 3scale API Management Platform* link.
-
 . Log in to link:{3scale-admin-url}[3scale Admin, window="_blank"] web console using `{user-username}` and password: `{user-password}`.
 +
 image::images/01-login.png[3scale-admin-login, role="integr8ly-img-responsive"]

--- a/docs/labs/developer-track/lab05/walkthrough.adoc
+++ b/docs/labs/developer-track/lab05/walkthrough.adoc
@@ -43,10 +43,6 @@ Your password is: `{user-password}`
 
 Your 3scale Admin Portal provides access to a number of configuration features. An administration token is needed when automating setups for your API. This step will let you create a new token for setup.
 
-. Launch a new tab on your web browser.
-. Navigate to the Solution Explorer on that tab.
-. Click on the *Red Hat 3scale API Management Platform* link.
-
 . Log in to link:{3scale-admin-url}[3scale Admin, window="_blank"] web console using `{user-username}` and password: `{user-password}`. Click on *Sign in*.
 +
 image::images/01-login.png[01-login.png, role="integr8ly-img-responsive"]


### PR DESCRIPTION
Users get "wrong password" when accessing 3Scale through the solution explorer. Using the link provided directly in the guide yields the correct result.