### PR TITLE
Minor adjustments on Lab 4 in the 'Update the Camel Route'-step 

### DIFF
--- a/docs/labs/developer-track/lab04/walkthrough.adoc
+++ b/docs/labs/developer-track/lab04/walkthrough.adoc
@@ -110,7 +110,7 @@ image::images/00-verify-pojos.png[00-verify-pojos.png, role="integr8ly-img-respo
 [id="instructions"]
 == Update the Camel Route
 
-. Open up the `CamelRoutes.java` file.  Notice that the existing implementation is barebones. First of all, we need to enter the SOAP service address and WSDL location for our CXF client to call.  Secondly, we need to create our Camel route implementation and create the RESTful endpoint. Make sure the values to ("cxf://` URL): are correct
+. Open up the `CamelRoutes.java` file.  Notice that the existing implementation is barebones. First of all, we need to enter the SOAP service address and WSDL location for our CXF client to call.
 +
 [source,java,subs="attributes+"]
 ----
@@ -124,6 +124,15 @@ image::images/00-verify-pojos.png[00-verify-pojos.png, role="integr8ly-img-respo
 
  @Override
  public void configure() throws Exception {
+
+ ...
+
+----
+
+. Secondly, we need to create our Camel route implementation and create the RESTful endpoint(still in the `CamelRoutes.java` file). Make sure the values to (`cxf://` URL): are correct
++
+[source,java,subs="attributes+"]
+----
 
  ...
 


### PR DESCRIPTION
Split java code-block into two separate tasks with related codeblocks. 
One with the attribute setup and the other with the camel route implementation. 

In a workshop attendants did a paste of the code without realising there was to be some code left intact between and hence couldn't get it to work. 